### PR TITLE
Added deep copy into delete function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ module.exports = {
                 const _temp = file.url.replace(containerURL.url, '');
                 const pathParts = _temp.split('/').filter(x => x.length > 0);
                 const fileName = pathParts.splice(pathParts.length - 1, 1);
-                const containerWithPath = containerURL;
+                const containerWithPath = Object.assign({}, containerURL);
                 containerWithPath.url += '/' + pathParts.join('/');
 
                 const blobURL = BlobURL.fromContainerURL(containerWithPath, fileName);


### PR DESCRIPTION
Added deep copy of containerURL to delete function. 
ContainerURL was changing during the whole lifetime of the application.
Deleting of files caused issues with the blob paths, ultimately leading deletion failing and upload being impossible