### PR TITLE
Update for v4 to get provider plugin working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,17 @@ This is an example plugins.js file for Azure storage:
 ```JavaScript
 module.exports = ({ env }) => ({
   upload: {
-    provider: 'azure-storage',
-    providerOptions: {
-      account: env('STORAGE_ACCOUNT'),
-      accountKey: env('STORAGE_ACCOUNT_KEY'),
-      serviceBaseURL: env('STORAGE_URL'),
-      containerName: env('STORAGE_CONTAINER_NAME'),
-      cdnBaseURL: env('STORAGE_CDN_URL'),
-      defaultPath: 'assets',
-      maxConcurrent: 10
+    config: {
+      provider: 'strapi-provider-upload-azure-storage',
+      providerOptions: {
+        account: env('STORAGE_ACCOUNT'),
+        accountKey: env('STORAGE_ACCOUNT_KEY'),
+        serviceBaseURL: env('STORAGE_URL'),
+        containerName: env('STORAGE_CONTAINER_NAME'),
+        cdnBaseURL: env('STORAGE_CDN_URL'),
+        defaultPath: 'assets',
+        maxConcurrent: 10
+      }
     }
   }
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,9 +63,13 @@ module.exports = {
                 const blobURL = BlobURL.fromContainerURL(containerWithPath, fileName);
                 const blockBlobURL = BlockBlobURL.fromBlobURL(blobURL);
 
-                file.url = cdnBaseURL 
-                    ? blobURL.url.replace(serviceBaseURL, cdnBaseURL)
-                    : blobURL.url;
+                if (cdnBaseURL) {
+                    file.url = cdnBaseURL 
+                        ? blobURL.url.replace(serviceBaseURL, cdnBaseURL)
+                        : blobURL.url;
+                } else {
+                    file.url = blobURL.url
+                }
 
                 return uploadStreamToBlockBlob(
                     Aborter.timeout(60 * 60 * 1000),


### PR DESCRIPTION
- Change for readme given new config object required on provider https://github.com/strapi/strapi/pull/11731
- Change for blob config (unsure if this is an issue with my azure setup, but isnt an issue on V3, breaks on V4)
Thanks to derrickmehaffy@strapi for support

With the rewrite of the get-enabled-plugins.js in strapi the provider name needs to be the full package name and not the provider name in config/plugins.js. This is due to the way the plugin provider pulls strapi plugins in assuming they are scoped to strapi. 