### PR TITLE
Add uploadStream method.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,30 @@ module.exports = {
                     }
                 ).then(resolve, reject);
             }),
+            uploadStream: file => new Promise((resolve, reject) => {
+                const fileName = file.hash + file.ext;
+                const containerWithPath = Object.assign({}, containerURL);
+                containerWithPath.url += file.path ? `/${file.path}` : `/${config.defaultPath}`;
+
+                const blobURL = BlobURL.fromContainerURL(containerWithPath, fileName);
+                const blockBlobURL = BlockBlobURL.fromBlobURL(blobURL);
+
+                file.url = cdnBaseURL 
+                    ? blobURL.url.replace(serviceBaseURL, cdnBaseURL)
+                    : blobURL.url;
+
+                return uploadStreamToBlockBlob(
+                    Aborter.timeout(60 * 60 * 1000),
+                    file.stream, blockBlobURL,
+                    4 * 1024 * 1024,
+                    ~~(config.maxConcurent) || 20,
+                    {
+                        blobHTTPHeaders: {
+                            blobContentType: file.mime
+                        }
+                    }
+                ).then(resolve, reject);
+            }),
             delete: file => new Promise((resolve, reject) => {
                 let fileUrl = file.url;
                 if (cdnBaseURL) {


### PR DESCRIPTION
Add uploadStream method to resolve issue #43 .

To use file.stream directly, this method does not make BufferStream instance. [https://docs.strapi.io/developer-docs/latest/plugins/upload.html#create-providers](url)