### PR TITLE
Specify what to add to the middleware.js in case using Azurite

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ module.exports = [
             /**
              * Note: If using a STORAGE_URL replace `https://${process.env.STORAGE_ACCOUNT}.blob.core.windows.net` w/ process.env.STORAGE_URL
              * If using a CDN URL make sure to include that url in the CSP headers process.env.STORAGE_CDN_URL
+             * If using Azurite, add the Blob Service base URL here, e.g. http://localhost:10000 
              */
             `https://${process.env.STORAGE_ACCOUNT}.blob.core.windows.net`,
           ],
@@ -99,6 +100,7 @@ module.exports = [
             /**
              * Note: If using a STORAGE_URL replace `https://${process.env.STORAGE_ACCOUNT}.blob.core.windows.net` w/ process.env.STORAGE_URL
              * If using a CDN URL make sure to include that url in the CSP headers process.env.STORAGE_CDN_URL
+             * If using Azurite, add the Blob Service base URL here, e.g. http://localhost:10000 
              */
             `https://${process.env.STORAGE_ACCOUNT}.blob.core.windows.net`,
 


### PR DESCRIPTION
In case of connecting to Azurite, using the STORAGE_URL (which contains the account name) in the contentSecurityPolicy directives won't solve the [issues](https://github.com/jakeFeldman/strapi-provider-upload-azure-storage/issues/68) caused by the Strapi Security Middleware.

In this case, the Blob service base URL should be added.
