### PR TITLE
Add cache control setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module.exports = ({ env }) => ({
         containerName: env("STORAGE_CONTAINER_NAME"),
         defaultPath: "assets",
         cdnBaseURL: env("STORAGE_CDN_URL"), // optional
+        defaultCacheControl: env("STORAGE_CACHE_CONTROL") // optional
       },
     },
   },
@@ -60,6 +61,7 @@ module.exports = ({ env }) => ({
 | containerName  | true     | Container name |
 | defaultPath  | true     | The path to use when there is none being specified. Defaults to `assets` |
 | cdnBaseURL  | false     | CDN base url |
+| defaultCacheControl  | false     | Cache-Control header value for all uploaded files |
 
 ### Security Middleware Configuration
 
@@ -119,6 +121,9 @@ module.exports = [
 When `serviceBaseURL` is not provided, default `https://${account}.blob.core.windows.net` will be used.
 
 `cdnBaseURL` is optional, it is useful when using CDN in front of your storage account. Images will be returned with the CDN URL instead of the storage account URL.
+
+`defaultCacheControl` is optional. It is useful when you want to allow clients to use a cached version of the file. Azure storage will return this value in the [`Cache-Control` HTTP-header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control?retiredLocale=de) of the response. 
+
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ type Config = {
     containerName: string;
     defaultPath: string;
     cdnBaseURL?: string;
+    defaultCacheControl?: string;
 };
 
 type StrapiFile = File & {
@@ -69,7 +70,10 @@ async function handleUpload(
     const containerClient = blobSvcClient.getContainerClient(trimParam(config.containerName));
     const client = containerClient.getBlockBlobClient(getFileName(config.defaultPath, file));
     const options = {
-        blobHTTPHeaders: { blobContentType: file.mime },
+        blobHTTPHeaders: { 
+            blobContentType: file.mime,
+            blobCacheControl: trimParam(config.defaultCacheControl)
+        },
     };
 
     const cdnBaseURL = trimParam(config.cdnBaseURL);
@@ -119,6 +123,10 @@ module.exports = {
         },
         cdnBaseURL: {
             label: 'CDN base url (optional)',
+            type: 'text',
+        },
+        defaultCacheControl: {
+            label: 'Default cache-control setting for all uploaded files',
             type: 'text',
         },
     },


### PR DESCRIPTION
I wanted to add the `cache-control` header to my uploaded files to improve caching on my clients.

I used the field from the documentation here:
https://learn.microsoft.com/de-de/javascript/api/@azure/storage-blob/blobhttpheaders?view=azure-node-latest#@azure-storage-blob-blobhttpheaders-blobcachecontrol

Since I'm new to TypeScript, please check my PR thoroughly 😄 