### PR TITLE
docs: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ module.exports = [
             "'self'",
             "data:",
             "blob:",
-            "dl.airtable.com",
-            "https://market-assets.strapi.io",
+            "dl.airtable.com", // Required for Strapi < 4.10.6, you can remove it otherwise
+            "https://market-assets.strapi.io", // Required for Strapi >= 4.10.6, you can remove it otherwise
             /**
              * Note: If using a STORAGE_URL replace `https://${process.env.STORAGE_ACCOUNT}.blob.core.windows.net` w/ process.env.STORAGE_URL
              * If using a CDN URL make sure to include that url in the CSP headers process.env.STORAGE_CDN_URL
@@ -134,7 +134,7 @@ module.exports = [
             "'self'",
             "data:",
             "blob:",
-            "dl.airtable.com",
+            "dl.airtable.com", // Required for Strapi < 4.10.6, you can remove it otherwise
             /**
              * Note: If using a STORAGE_URL replace `https://${process.env.STORAGE_ACCOUNT}.blob.core.windows.net` w/ process.env.STORAGE_URL
              * If using a CDN URL make sure to include that url in the CSP headers process.env.STORAGE_CDN_URL


### PR DESCRIPTION
According to https://github.com/strapi/strapi/pull/16746 the airtable domain is not useful anymore from Strapi 4.10.6