### PR TITLE
Updating Managed Identity Auth Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ module.exports = ({ env }) => ({
 });
 
 // For using azure identities, the correct authType is 'msi' or (provide it in the environment variable)
+// clientId is used for Azure User-Assigned Identity access. If not provided, system-assigned managed identity is used instead
+// RBAC Role Storage Blob Data Contributor required for MSI   
 
 module.exports = ({ env }) => ({
   upload: {
@@ -82,21 +84,21 @@ module.exports = ({ env }) => ({
 
 ```
 
-| Property                  | Required                                      | Description                                                                                   |
-| ------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| authType                  | true                                          | Whether to use a SAS key ("default") or an identity ("msi")                                   |
-| account                   | true                                          | Azure account name                                                                            |
-| accountKey                | if 'authType 'default'                        | Secret access key                                                                             |
-| clientId                  | false (consumed if 'authType 'msi')           | Azure Identity Client ID                                                                      |
-| sasToken                  | false                                         | SAS Token, either accountKey or SASToken is required if 'authType is 'default'                |
-| serviceBaseURL            | false                                         | Base service URL to be used, optional. Defaults to `https://${account}.blob.core.windows.net` |
-| containerName             | true                                          | Container name                                                                                |
-| createContainerIfNotExist | false                                         | Attempts to create the container if not existing. Must be one of 'true' or any string         |
-| publicAccessType          | false (param for 'createContainerIfNotExist') | Sets the public access of a newly created container to one of 'blob' or 'container'           |
-| defaultPath               | true                                          | The path to use when there is none being specified. Defaults to `assets`                      |
-| cdnBaseURL                | false                                         | CDN base url                                                                                  |
-| defaultCacheControl       | false                                         | Cache-Control header value for all uploaded files                                             |
-| removeCN                  | false                                         | Set to true, to remove container name from azure URL                                          |
+| Property                  | Required                                      | Description                                                                                           |
+| ------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------|
+| authType                  | true                                          | Whether to use a SAS key ("default") or an identity ("msi")                                           |
+| account                   | true                                          | Azure account name                                                                                    |
+| accountKey                | if 'authType 'default'                        | Secret access key                                                                                     |
+| clientId                  | false (consumed if 'authType 'msi')           | Azure user-assigned identity client ID. If not provided, system-assigned managed identity ID is used  |
+| sasToken                  | false                                         | SAS Token, either accountKey or SASToken is required if 'authType is 'default'                        |
+| serviceBaseURL            | false                                         | Base service URL to be used, optional. Defaults to `https://${account}.blob.core.windows.net`         |
+| containerName             | true                                          | Container name                                                                                        |
+| createContainerIfNotExist | false                                         | Attempts to create the container if not existing. Must be one of 'true' or any string                 |
+| publicAccessType          | false (param for 'createContainerIfNotExist') | Sets the public access of a newly created container to one of 'blob' or 'container'                   |
+| defaultPath               | true                                          | The path to use when there is none being specified. Defaults to `assets`                              |
+| cdnBaseURL                | false                                         | CDN base url                                                                                          |
+| defaultCacheControl       | false                                         | Cache-Control header value for all uploaded files                                                     |
+| removeCN                  | false                                         | Set to true, to remove container name from azure URL                                                  |
 
 
 ### Security Middleware Configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-provider-upload-azure-storage",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Updating the documentation to differentiate between User-Assigned and System-Assigned managed identities
https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview

My goal was to explain a little more clearly that:

```
If authType is set to MSI and clientId is provided, it uses User-Assigned managed identity. 
If authType is set to MSI and clientId is not provided, it uses System-Assigned managed identity.
```

I also added a small note re: recommended RBAC permissions needed for this plugin to work

Storage Blob Data Contributor
https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor
