### PR TITLE
Remove incorrect config.removeCN boolean expression

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,8 +130,7 @@ async function handleUpload(
     file.url = cdnBaseURL ? client.url.replace(serviceBaseURL, cdnBaseURL) : client.url;
     if (
         file.url.includes(`/${config.containerName}/`) &&
-        config.removeCN &&
-        config.removeCN == 'true'
+        config.removeCN
     ) {
         file.url = file.url.replace(`/${config.containerName}/`, '/');
     }


### PR DESCRIPTION
JavaScript evaluates the expression `config.removeCN == 'true'` is evaluated as `false`. This meant that the container name was never being removed, even when removeCN was set as true.

As a workaround you can set removeCN: 'true' in the meantime.