### PR TITLE
fix: removeCN now strips percent-encoded container names (e.g. %24web)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,12 +128,14 @@ async function handleUpload(
 
     const cdnBaseURL = trimParam(config.cdnBaseURL);
     file.url = cdnBaseURL ? client.url.replace(serviceBaseURL, cdnBaseURL) : client.url;
-    if (
-        file.url.includes(`/${config.containerName}/`) &&
-        config.removeCN &&
-        config.removeCN == 'true'
-    ) {
-        file.url = file.url.replace(`/${config.containerName}/`, '/');
+    if (config.removeCN && config.removeCN === 'true') {
+        const rawSegment = `/${config.containerName}/`;
+        const encodedSegment = `/${encodeURIComponent(config.containerName)}/`;
+        if (file.url.includes(rawSegment)) {
+            file.url = file.url.replace(rawSegment, '/');
+        } else if (file.url.includes(encodedSegment)) {
+            file.url = file.url.replace(encodedSegment, '/');
+        }
     }
 
     await client.uploadStream(


### PR DESCRIPTION
### What
This fixes an edge case where `removeCN: 'true'` fails to strip container names containing reserved characters (e.g. `$web` → `%24web`) from the final URL.

### Why
- The Azure SDK percent‐encodes `$` as `%24`, so our existing `file.url.replace('/$web/', '/')` never matched.
- Public URLs still showed `/%24web/…`, which breaks the URL and the resource is not found.

### How
- Added a second replace to catch the `/%24web/` form:
  ```ts
  // after replacing serviceBaseURL with cdnBaseURL…
  if (config.removeCN && config.removeCN === 'true') {
        const rawSegment = `/${config.containerName}/`;
        const encodedSegment = `/${encodeURIComponent(config.containerName)}/`; //eg: %24web
        if (file.url.includes(rawSegment)) {
            file.url = file.url.replace(rawSegment, '/');
        } else if (file.url.includes(encodedSegment)) {
            file.url = file.url.replace(encodedSegment, '/');
        }
    }
